### PR TITLE
Add hashes to Documents to allow for future work

### DIFF
--- a/pkg/workspace/documents/document.go
+++ b/pkg/workspace/documents/document.go
@@ -6,5 +6,6 @@ import (
 
 type Document struct {
 	lastUpdated int64
+	Hash        string
 	ast.Document
 }

--- a/pkg/workspace/documents/processor.go
+++ b/pkg/workspace/documents/processor.go
@@ -2,6 +2,8 @@ package documents
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"os"
@@ -44,8 +46,14 @@ func (c *Client) processFile(path string) {
 			return
 		}
 
+		// Work out the hash of the contents
+		hash := sha256.New()
+		hash.Write(contents)
+		hashSum := hash.Sum(nil)
+		hashStr := hex.EncodeToString(hashSum)
+
 		slog.Debug("updating document in cache", slog.String("file", path), slog.String("relative", rel))
-		doc := Document{Document: d, lastUpdated: time.Now().Unix()}
+		doc := Document{Document: d, lastUpdated: time.Now().Unix(), Hash: hashStr}
 
 		c.docMutex.Lock()
 		c.documents[rel] = doc

--- a/pkg/workspace/tasks/fetchers.go
+++ b/pkg/workspace/tasks/fetchers.go
@@ -1,12 +1,10 @@
 package tasks
 
-import "github.com/liamawhite/nl/pkg/ast"
-
-type TaskFetcher func(c *Client) ([]ast.Task, error)
+type TaskFetcher func(c *Client) ([]Task, error)
 
 func FetchAllTasks() TaskFetcher {
-	return func(c *Client) ([]ast.Task, error) {
-		var tasks []ast.Task
+	return func(c *Client) ([]Task, error) {
+		var tasks []Task
 		c.mutex.RLock()
 		for _, document := range c.cache {
 			for _, task := range document {
@@ -19,8 +17,8 @@ func FetchAllTasks() TaskFetcher {
 }
 
 func FetchTasksForDocument(document string) TaskFetcher {
-	return func(c *Client) ([]ast.Task, error) {
-		var tasks []ast.Task
+	return func(c *Client) ([]Task, error) {
+		var tasks []Task
 		c.mutex.RLock()
 		for _, task := range c.cache[document] {
 			tasks = append(tasks, *task)

--- a/pkg/workspace/tasks/fetchers_test.go
+++ b/pkg/workspace/tasks/fetchers_test.go
@@ -11,7 +11,7 @@ func TestFetchAllTasks(t *testing.T) {
 	events := defaultEvents()
 	c, _ := buildClient(events...)
 	tasks, err := c.ListTasks(tasks.FetchAllTasks())
-	wantTasks := append(events[0].Document.Tasks, events[1].Document.Tasks...)
+	wantTasks := append(tasksBuilder(events[0].Document), tasksBuilder(events[1].Document)...)
 
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, wantTasks, tasks)
@@ -21,7 +21,7 @@ func TestFetchTasksForDocument(t *testing.T) {
 	events := defaultEvents()
 	c, _ := buildClient(events...)
 	tasks, err := c.ListTasks(tasks.FetchTasksForDocument("two.md"))
-	wantTasks := events[1].Document.Tasks
+	wantTasks := tasksBuilder(events[1].Document)
 
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, wantTasks, tasks)

--- a/pkg/workspace/tasks/filters.go
+++ b/pkg/workspace/tasks/filters.go
@@ -2,11 +2,11 @@ package tasks
 
 import "github.com/liamawhite/nl/pkg/ast"
 
-type TaskFilter func(ast.Task) bool
+type TaskFilter func(Task) bool
 
-// Priorities are OR'd together
+// Priorities are OR'd together because a task can only have one priority
 func FilterByPriority(priority ...int) TaskFilter {
-	return func(task ast.Task) bool {
+	return func(task Task) bool {
 		for _, p := range priority {
 			if task.Priority != nil && *task.Priority == p {
 				return true
@@ -16,8 +16,9 @@ func FilterByPriority(priority ...int) TaskFilter {
 	}
 }
 
+// Statuses are OR'd together because a task can only have one status
 func FilterByStatus(status ...ast.Status) TaskFilter {
-	return func(task ast.Task) bool {
+	return func(task Task) bool {
 		for _, s := range status {
 			if task.Status == s {
 				return true

--- a/pkg/workspace/tasks/filters_test.go
+++ b/pkg/workspace/tasks/filters_test.go
@@ -15,27 +15,27 @@ func TestFilters(t *testing.T) {
 	tests := []struct {
 		name      string
 		filter    tasks.TaskFilter
-		wantTasks []ast.Task
+		wantTasks []tasks.Task
 	}{
 		{
 			name:      "Filter by single priority",
 			filter:    tasks.FilterByPriority(1),
-			wantTasks: []ast.Task{events[0].Document.Tasks[1]},
+			wantTasks: []tasks.Task{toTask(events[0].Document.Tasks[1], events[0].Document.Hash)},
 		},
 		{
 			name:      "Filter by multiple priorities",
 			filter:    tasks.FilterByPriority(1, 2),
-			wantTasks: []ast.Task{events[0].Document.Tasks[1], events[1].Document.Tasks[0]},
+			wantTasks: []tasks.Task{toTask(events[0].Document.Tasks[1], events[0].Document.Hash), toTask(events[1].Document.Tasks[0], events[1].Document.Hash)},
 		},
 		{
 			name:      "Filter by status",
 			filter:    tasks.FilterByStatus(ast.Done),
-			wantTasks: []ast.Task{events[1].Document.Tasks[0]},
+			wantTasks: []tasks.Task{toTask(events[1].Document.Tasks[0], events[1].Document.Hash)},
 		},
 		{
 			name:      "Filter by multiple statuses",
 			filter:    tasks.FilterByStatus(ast.Todo, ast.Done),
-			wantTasks: []ast.Task{events[0].Document.Tasks[0], events[1].Document.Tasks[0]},
+			wantTasks: []tasks.Task{toTask(events[0].Document.Tasks[0], events[0].Document.Hash), toTask(events[1].Document.Tasks[0], events[1].Document.Hash)},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/workspace/tasks/utils_test.go
+++ b/pkg/workspace/tasks/utils_test.go
@@ -28,6 +28,18 @@ func intPtr(i int) *int {
 	return &i
 }
 
+func tasksBuilder(doc documents.Document) []tasks.Task {
+	res := make([]tasks.Task, len(doc.Tasks))
+	for i, t := range doc.Tasks {
+		res[i] = toTask(t, doc.Hash)
+	}
+	return res
+}
+
+func toTask(t ast.Task, documentHash string) tasks.Task {
+	return tasks.Task{Task: t, DocumentHash: documentHash}
+}
+
 func defaultEvents() []documents.Event {
 	return []documents.Event{
 		{


### PR DESCRIPTION
For future functionality like updating/deleting tasks we need to ensure we don't write using stale data. To combat this we will reject based on the document hash at the time of instantiation for the in memory task.

This is a relatively dumb way of doing this but let's keep it simple until there are actual UX reasons for doing something more complicated.